### PR TITLE
Handle crash

### DIFF
--- a/main.go
+++ b/main.go
@@ -88,8 +88,10 @@ func main() {
 		from, to := fp.Files()
 		if to != nil {
 			patchByName[to.Path()] = fp
-		} else {
+		} else if from != nil {
 			patchByName[from.Path()] = fp
+		} else {
+			continue
 		}
 		if to != nil {
 			forkFiles[to.Path()] = struct{}{}


### PR DESCRIPTION
I ran into this error:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x8b2577]
```

Turns out there is some weird case where both `from` and `to` are `nil`. I'm not sure how this is possible, but handling it fixes the crash for me.
