### PR TITLE
Add optional flag for upstream local repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Usage:
     fork page definition (default "fork.yaml")
 -out string
     output (default "index.html")
+-upstream-repo string (optional)
+    path to local git repository (default value of -repo)
 ```
 
 The `fork.yaml` defines the page structure, to organize and document the diff of the fork.


### PR DESCRIPTION
### Description
Adds an optional `upstream-repo` parameter to make it possible to look for the base commit in a separate local repository. This allows for running formatters (i.e. `gofmt`) on the base & forked commits locally and diff them afterwards.

When not set, this defaults to the value of `repo`, which should keep behavior backwards compatible.

Updated README to reflect this as well.

### Tested
Tested this locally.